### PR TITLE
Fix dashboard redirect for student users

### DIFF
--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -48,7 +48,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
             default                          => route('home'),
         };
 
-        $this->redirectIntended(default: $to, navigate: true);
+        $this->redirectIntended(default: $to);
     }
 
     protected function ensureIsNotRateLimited(): void


### PR DESCRIPTION
## Summary
- use standard redirect after login to avoid 404 when student is sent to dashboard

## Testing
- `php artisan test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2bb21c74832abf5d9bb95918402b