### PR TITLE
Disable email verification requirement for dashboard access

### DIFF
--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -48,7 +48,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
             default                          => route('home'),
         };
 
-        $this->redirectIntended(default: $to, navigate: true);
+        $this->redirectIntended(default: $to, navigate: false);
     }
 
     protected function ensureIsNotRateLimited(): void

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,8 +13,8 @@ Route::get('/', function () {
 Volt::route('register', 'auth.register')->middleware('guest')->name('register');
 Volt::route('login', 'auth.login')->middleware('guest')->name('login');
 
-// ⚙️ Configuración (logueados + verificado)
-Route::middleware(['auth', 'verified'])->group(function () {
+// ⚙️ Configuración (solo usuarios autenticados)
+Route::middleware(['auth'])->group(function () {
     Route::redirect('settings', 'settings/profile');
 
     Volt::route('settings/profile', 'settings.profile')->name('settings.profile');
@@ -24,22 +24,22 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
 // 🛡️ Admin (ruta creada; vista/volt se hará luego)
 Volt::route('admin/dashboard', 'admin.dashboard')
-    ->middleware(['auth', 'verified', 'role:admin'])
+    ->middleware(['auth', 'role:admin'])
     ->name('admin.dashboard');
 
 // 👨‍🏫 Dashboard Profesor
 Volt::route('profesor', 'profesor.dashboard')
-    ->middleware(['auth', 'verified', 'role:profesor'])
+    ->middleware(['auth', 'role:profesor'])
     ->name('profesor.dashboard');
 
 // 🎓 Dashboard Estudiante (su propio perfil)
 Volt::route('dashboard', 'estudiante.dashboard')
-    ->middleware(['auth', 'verified', 'role:estudiante'])
+    ->middleware(['auth', 'role:estudiante'])
     ->name('dashboard');
 
 // 👀 Ver perfil de estudiante (solo admin/profesor)
 Volt::route('estudiantes/{profile}', 'estudiante.dashboard')
-    ->middleware(['auth', 'verified', 'can:view,profile'])
+    ->middleware(['auth', 'can:view,profile'])
     ->name('estudiantes.show');
 
 require __DIR__ . '/auth.php';

--- a/tests/Feature/RoleRoutesTest.php
+++ b/tests/Feature/RoleRoutesTest.php
@@ -10,16 +10,16 @@ beforeEach(function () {
 
     Route::middleware(['web'])->group(function () {
         Route::get('/__t/admin', fn () => 'ADMIN_OK')
-            ->middleware(['auth','verified','role:admin']);
+            ->middleware(['auth','role:admin']);
 
         Route::get('/__t/profesor', fn () => 'PROF_OK')
-            ->middleware(['auth','verified','role:profesor']);
+            ->middleware(['auth','role:profesor']);
 
         Route::get('/__t/estudiante', fn () => 'ESTU_OK')
-            ->middleware(['auth','verified','role:estudiante']);
+            ->middleware(['auth','role:estudiante']);
 
         Route::get('/__t/panel', fn () => 'PANEL_OK')
-            ->middleware(['auth','verified','role:admin,2']);
+            ->middleware(['auth','role:admin,2']);
     });
 });
 


### PR DESCRIPTION
## Summary
- Allow authenticated users to access settings and dashboards without needing a verified email
- Adjust route tests to match removal of the `verified` middleware

## Testing
- ⚠️ `npm run build` (Can't resolve '../../vendor/livewire/flux/dist/flux.css')
- ⚠️ `php artisan test` (Missing application encryption key; multiple failing tests)


------
https://chatgpt.com/codex/tasks/task_e_68aa2bb21c74832abf5d9bb95918402b